### PR TITLE
dist: include Dockerfile in build context

### DIFF
--- a/dist/build_deploy.sh
+++ b/dist/build_deploy.sh
@@ -15,6 +15,7 @@ function cleanup() {
     set +e
     if [[ ! -n "$KEEP_RELEASE_OUTPUT" ]]; then
         rm -f ${RELEASE_OUTPUT_DIR}/{graph-builder,policy-engine}
+        rm -f ${RELEASE_OUTPUT_DIR}/$(basename ${DOCKERFILE_DEPLOY})
         rmdir ${RELEASE_OUTPUT_DIR}
     fi
     docker_cargo clean
@@ -23,9 +24,9 @@ trap cleanup EXIT
 
 docker_cargo build --release
 mkdir $RELEASE_OUTPUT_DIR
-cp ${RELEASE_DIR}/{graph-builder,policy-engine} $RELEASE_OUTPUT_DIR/
+cp ${RELEASE_DIR}/{graph-builder,policy-engine} $DOCKERFILE_DEPLOY  $RELEASE_OUTPUT_DIR/
 
-docker build -f $DOCKERFILE_DEPLOY -t "${IMAGE}:${IMAGE_TAG}" $RELEASE_OUTPUT_DIR
+docker build -t "${IMAGE}:${IMAGE_TAG}" $RELEASE_OUTPUT_DIR
 
 if [[ -n "$QUAY_USER" && -n "$QUAY_TOKEN" ]]; then
     DOCKER_CONF="$PWD/.docker"


### PR DESCRIPTION
This seems to be necessary on the CI accordin to the error message:

```log
unable to prepare context: The Dockerfile
(/var/lib/jenkins/workspace/openshift-cincinnati-gh-build-master/dist/Dockerfile)
must be within the build context
(/var/lib/jenkins/workspace/openshift-cincinnati-gh-build-master/dist/..//release-20181204.181943)
```