### PR TITLE
graph-builder/registry: tolerate tags w/o releases and improve logging

### DIFF
--- a/graph-builder/src/graph.rs
+++ b/graph-builder/src/graph.rs
@@ -80,8 +80,18 @@ fn create_graph(
 ) -> Result<Graph, Error> {
     let mut graph = Graph::default();
 
-    registry::fetch_releases(&opts.registry, &opts.repository, username, password)
-        .context("failed to fetch all release metadata")?
+    let releases = registry::fetch_releases(&opts.registry, &opts.repository, username, password)
+        .context("failed to fetch all release metadata")?;
+
+    if releases.is_empty() {
+        warn!(
+            "could not find any releases in {}/{}",
+            &opts.registry, &opts.repository
+        );
+        return Ok(graph);
+    };
+
+    releases
         .into_iter()
         .inspect(|release| trace!("Adding a release to the graph '{:?}'", release))
         .try_for_each(|release| {

--- a/graph-builder/src/main.rs
+++ b/graph-builder/src/main.rs
@@ -32,8 +32,8 @@ extern crate serde_json;
 #[macro_use]
 extern crate structopt;
 extern crate tar;
-extern crate tokio_core;
 extern crate tokio;
+extern crate tokio_core;
 
 mod config;
 mod graph;

--- a/graph-builder/src/registry.rs
+++ b/graph-builder/src/registry.rs
@@ -125,6 +125,7 @@ pub fn fetch_releases(
                 tag.to_owned(),
             )
         })
+        .filter_map(|release| release)
         .collect();
 
     thread_runtime.block_on(releases)
@@ -163,7 +164,7 @@ fn find_first_release(
     registry_host: String,
     repo: String,
     tag: String,
-) -> impl Future<Item = Release, Error = Error> {
+) -> impl Future<Item = Option<Release>, Error = Error> {
     let tag_for_error = tag.clone();
 
     let releases = layer_digests.into_iter().map(move |layer_digest| {
@@ -203,14 +204,15 @@ fn find_first_release(
 
     futures::stream::iter_ok::<_, Error>(releases)
         .flatten()
-        .into_future()
-        .map_err(|(e, _)| e)
-        .and_then(move |(release, _)| match release {
-            Some(release) => Ok(release),
-            None => Err(format_err!(
-                "could not find any release in tag {}",
-                tag_for_error
-            )),
+        .take(1)
+        .collect()
+        .map(move |mut releases| {
+            if releases.is_empty() {
+                warn!("could not find any release in tag {}", tag_for_error);
+                None
+            } else {
+                Some(releases.remove(0))
+            }
         })
 }
 

--- a/graph-builder/src/registry.rs
+++ b/graph-builder/src/registry.rs
@@ -191,10 +191,9 @@ fn find_first_release(
                         metadata,
                     }),
                     Err(e) => {
-                        trace!(
-                            "could not assemble metadata from layer ({}): {}",
-                            &layer_digest,
-                            e,
+                        debug!(
+                            "could not assemble metadata from layer ({}) of tag '{}': {}",
+                            &layer_digest, &tag, e,
                         );
                         None
                     }


### PR DESCRIPTION
A test for this case exists over in #11.