### PR TITLE
update dkregistry to include fix for next_page

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1284,7 +1284,7 @@ dependencies = [
 [[package]]
 name = "dkregistry"
 version = "0.5.1-alpha.0"
-source = "git+https://github.com/camallo/dkregistry-rs.git?rev=37acecb4b8139dd1b1cc83795442f94f90e1ffc5#37acecb4b8139dd1b1cc83795442f94f90e1ffc5"
+source = "git+https://github.com/camallo/dkregistry-rs.git?rev=abb58c140fba8bebae3d20ea4290c52147468e27#abb58c140fba8bebae3d20ea4290c52147468e27"
 dependencies = [
  "async-stream",
  "base64 0.13.0",

--- a/cincinnati/Cargo.toml
+++ b/cincinnati/Cargo.toml
@@ -31,7 +31,7 @@ async-trait = "^0.1"
 tempfile = "^3.3.0"
 flate2 = "^1.0.25"
 tar = "^0.4.38"
-dkregistry = { git = "https://github.com/camallo/dkregistry-rs.git", rev = "37acecb4b8139dd1b1cc83795442f94f90e1ffc5" }
+dkregistry = { git = "https://github.com/camallo/dkregistry-rs.git", rev = "abb58c140fba8bebae3d20ea4290c52147468e27" }
 itertools = "^0.10"
 serde_yaml = "^0.8.23"
 prettydiff = { version = "0.6", optional = true }


### PR DESCRIPTION
ensures that cincinnati works with registries that do not use a "next_page" query parameter