### PR TITLE
OTA-1838: chore(Dockerfile): Use ubi-minimal for base images

### DIFF
--- a/dist/Dockerfile.deploy/Dockerfile
+++ b/dist/Dockerfile.deploy/Dockerfile
@@ -1,18 +1,18 @@
-FROM registry.access.redhat.com/ubi9/ubi:latest as builder
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest as builder
 WORKDIR /opt/app-root/src/
 COPY . .
 
-RUN dnf update -y \
-    && dnf install -y jq rust cargo \
-    && dnf install -y openssl-devel \
-    && dnf clean all \
+RUN microdnf update -y \
+    && microdnf install -y jq rust cargo \
+    && microdnf install -y openssl-devel \
+    && microdnf clean all \
     && cargo build --release \
     && mkdir -p /opt/cincinnati/bin \
     && cp -rvf target/release/graph-builder /opt/cincinnati/bin \
     && cp -rvf target/release/policy-engine /opt/cincinnati/bin \
     && cp -rvf target/release/metadata-helper /opt/cincinnati/bin
 
-FROM registry.access.redhat.com/ubi9/ubi:latest
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 ENV RUST_LOG=actix_web=error,dkregistry=error
 COPY --from=builder /opt/cincinnati/bin/* /usr/bin/
 


### PR DESCRIPTION
We do not need to update the base image in the build stage, but I do not see a reason why we should not use the minimal for all stages while we are at it.

The container image built using the Dockerfile is now being exercised in relevant CI presubmit jobs (https://github.com/openshift/release/pull/79424).