### PR TITLE
Simplify Dockerfile

### DIFF
--- a/dist/Dockerfile.deploy/Dockerfile
+++ b/dist/Dockerfile.deploy/Dockerfile
@@ -1,19 +1,10 @@
-FROM registry.access.redhat.com/ubi9/ubi-minimal:latest as builder
-WORKDIR /opt/app-root/src/
+FROM quay.io/openshift-ota/cincinnati-ci-public:rust_boot-root-1.84.1 as builder
 COPY . .
 
-RUN microdnf update -y \
-    && microdnf install -y jq rust cargo \
-    && microdnf install -y openssl-devel \
-    && microdnf clean all \
-    && cargo build --release \
-    && mkdir -p /opt/cincinnati/bin \
-    && cp -rvf target/release/graph-builder /opt/cincinnati/bin \
-    && cp -rvf target/release/policy-engine /opt/cincinnati/bin \
-    && cp -rvf target/release/metadata-helper /opt/cincinnati/bin
+RUN bin_folder="/go/bin" just build --release
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 ENV RUST_LOG=actix_web=error,dkregistry=error
-COPY --from=builder /opt/cincinnati/bin/* /usr/bin/
+COPY --from=builder /go/bin/graph-builder /go/bin/policy-engine /go/bin/metadata-helper /usr/bin/
 
 ENTRYPOINT ["/usr/bin/graph-builder"]


### PR DESCRIPTION
https://github.com/openshift/cincinnati/pull/1067 uses the ubi-minimal images.

> We do not need to update the base image in the build stage, but I do not see a reason why we should not use the minimal for all stages while we are at it.

This pull gives a reason: It saves the dependency installation in each CI build.

The build base is used in CI already as the build root [1] (and it is open to the public which should cause no troubles if we sync the changes to the Flux build). We should keep the CI build and the production build as close as possible if not identical [2]. Cincinnati is not an OCP product but the theory there can be applied.

The builder image is currently not based from ubi-minimal [3]. We could switch to it, e.g., when making the next build root image for a new Rust version.

In addition, the recipe `just build --release` is used to build the binaries, to keep doing things in a consistent way.

Basically this pull tries to reduce the changes on CI from https://github.com/openshift/release/pull/79424.

[1]. https://github.com/openshift/release/blob/76d0cff0192e04c1d90a535d72106bffab91e79a/ci-operator/config/openshift/cincinnati/openshift-cincinnati-master.yaml#L18-L22

[2]. https://docs.ci.openshift.org/architecture/images/

[3]. https://github.com/openshift/release/blob/76d0cff0192e04c1d90a535d72106bffab91e79a/ci-operator/config/openshift/cincinnati/openshift-cincinnati-master.yaml#L26