### PR TITLE
Set Content-Type header on /metrics response

### DIFF
--- a/commons/src/metrics.rs
+++ b/commons/src/metrics.rs
@@ -30,7 +30,9 @@ where
     let tenc = prometheus::TextEncoder::new();
     let mut buf = vec![];
     match tenc.encode(&metrics, &mut buf) {
-        Ok(()) => HttpResponse::Ok().body(buf),
+        Ok(()) => HttpResponse::Ok()
+            .content_type(tenc.format_type())
+            .body(buf),
         Err(e) => HttpResponse::InternalServerError().body(format!("{}", e)),
     }
 }


### PR DESCRIPTION
## What
`commons::metrics::serve()` returned the Prometheus text-exposition body via `HttpResponse::Ok().body(buf)` without setting a `Content-Type`, so actix-web sent no `Content-Type` header at all.

## Why
Legacy Prometheus (2.x) parses the response body as classic exposition text regardless of Content-Type, so this went unnoticed - the body itself is valid. Prometheus 3.x is stricter and rejects a blank Content-Type outright unless a `fallback_scrape_protocol` is configured, which caused App-SRE's newer Cluster Observability Operator Prometheus stack to report `graph-builder` and `policy-engine` targets as down while they worked fine under the legacy stack:
```
non-compliant scrape target sending blank Content-Type and no fallback_scrape_protocol specified for target
```
Confirmed live via the COO Prometheus target status on affected clusters.

## Fix
Set the response `Content-Type` from the encoder's own `format_type()` (`prometheus::TEXT_FORMAT` = `text/plain; version=0.0.4`), so it stays correct if the encoder implementation ever changes rather than hardcoding a string.

Ref: [APPSRE-13041](https://redhat.atlassian.net/browse/APPSRE-13041)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prometheus metrics responses now include the correct HTTP `Content-Type` header for successful textual output, improving compatibility with monitoring tools.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->