### PR TITLE
OCPBUGS-99935, OCPBUGS-100030: fix: replace opentelemetry-jaeger+thrift with opentelemetry-otlp

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -168,7 +168,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "mio",
- "socket2",
+ "socket2 0.5.8",
  "tokio",
  "tracing",
 ]
@@ -230,7 +230,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "smallvec",
- "socket2",
+ "socket2 0.5.8",
  "time",
  "tracing",
  "url",
@@ -750,7 +750,7 @@ dependencies = [
  "js-sys",
  "num-traits",
  "wasm-bindgen",
- "windows-link",
+ "windows-link 0.1.1",
 ]
 
 [[package]]
@@ -865,7 +865,8 @@ dependencies = [
  "log",
  "memchr",
  "opentelemetry",
- "opentelemetry-jaeger",
+ "opentelemetry-otlp",
+ "opentelemetry_sdk",
  "prometheus",
  "reqwest",
  "serde",
@@ -873,7 +874,6 @@ dependencies = [
  "serde_json",
  "tar",
  "thiserror 1.0.69",
- "thrift 0.17.0",
  "tokio",
  "url",
 ]
@@ -1783,9 +1783,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.8"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5017294ff4bb30944501348f6f8e42e6ad28f42c8bbef7a74029aff064a4e3c2"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1845,12 +1845,6 @@ checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "hermit-abi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "hermit-abi"
@@ -1962,14 +1956,15 @@ checksum = "9b112acc8b3adf4b107a8ec20977da0273a8c386765a3ec0229bd500a1443f9f"
 
 [[package]]
 name = "hyper"
-version = "1.6.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc2b571658e38e0c01b1fdca3bbbe93c00d3d71693ff2770043f8c29bc7d6f80"
+checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
 dependencies = [
+ "atomic-waker",
  "bytes",
  "futures-channel",
- "futures-util",
- "h2 0.4.8",
+ "futures-core",
+ "h2 0.4.15",
  "http 1.3.1",
  "http-body",
  "httparse",
@@ -2016,9 +2011,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.10"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df2dcfbe0677734ab2f3ffa7fa7bfd4706bfdc1ef393f2ee30184aed67e631b4"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -2026,8 +2021,9 @@ dependencies = [
  "http 1.3.1",
  "http-body",
  "hyper",
+ "libc",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.5",
  "tokio",
  "tower-service",
  "tracing",
@@ -2247,18 +2243,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "integer-encoding"
-version = "1.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48dc51180a9b377fd75814d0cc02199c20f8e99433d6762f650d39cdbbd3b56f"
-
-[[package]]
-name = "integer-encoding"
-version = "3.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
-
-[[package]]
 name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2355,9 +2339,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.171"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libflate"
@@ -2710,16 +2694,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num_cpus"
-version = "1.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
-dependencies = [
- "hermit-abi 0.3.9",
- "libc",
-]
-
-[[package]]
 name = "num_enum"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2830,50 +2804,74 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry"
-version = "0.14.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "492848ff47f11b7f9de0443b404e2c5775f695e1af6b7076ca25f999581d547a"
+checksum = "aaf416e4cb72756655126f7dd7bb0af49c674f4c1b9903e80c009e0c37e552e6"
 dependencies = [
- "async-trait",
- "crossbeam-channel",
- "futures",
+ "futures-core",
+ "futures-sink",
  "js-sys",
- "lazy_static",
- "percent-encoding",
- "pin-project",
- "rand 0.8.5",
- "thiserror 1.0.69",
+ "pin-project-lite",
+ "thiserror 2.0.12",
+ "tracing",
 ]
 
 [[package]]
-name = "opentelemetry-jaeger"
-version = "0.13.0"
+name = "opentelemetry-http"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97fd9ed34f208e0394bfb17522ba0d890925685dfd883147670ed474339d4647"
+checksum = "50f6639e842a97dbea8886e3439710ae463120091e2e064518ba8e716e6ac36d"
 dependencies = [
  "async-trait",
- "lazy_static",
+ "bytes",
+ "http 1.3.1",
  "opentelemetry",
- "thiserror 1.0.69",
- "thrift 0.13.0",
+ "reqwest",
 ]
 
 [[package]]
-name = "ordered-float"
-version = "1.1.1"
+name = "opentelemetry-otlp"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3305af35278dd29f46fcdd139e0b1fbfae2153f0e5928b39b035542dd31e37b7"
+checksum = "dbee664a43e07615731afc539ca60c6d9f1a9425e25ca09c57bc36c87c55852b"
 dependencies = [
- "num-traits",
+ "http 1.3.1",
+ "opentelemetry",
+ "opentelemetry-http",
+ "opentelemetry-proto",
+ "opentelemetry_sdk",
+ "prost",
+ "reqwest",
+ "thiserror 2.0.12",
+ "tracing",
 ]
 
 [[package]]
-name = "ordered-float"
-version = "2.10.1"
+name = "opentelemetry-proto"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
+checksum = "2e046fd7660710fe5a05e8748e70d9058dc15c94ba914e7c4faa7c728f0e8ddc"
 dependencies = [
- "num-traits",
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "prost",
+ "tonic",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11f644aa9e5e31d11896e024305d7e3c98a88884d9f8919dbf37a9991bc47a4b"
+dependencies = [
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "opentelemetry",
+ "percent-encoding",
+ "rand 0.9.0",
+ "serde_json",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -3270,6 +3268,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
 name = "protobuf"
 version = "2.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3334,7 +3355,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2",
+ "socket2 0.5.8",
  "thiserror 2.0.12",
  "tokio",
  "tracing",
@@ -3370,7 +3391,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2",
+ "socket2 0.5.8",
  "tracing",
  "windows-sys 0.59.0",
 ]
@@ -3513,7 +3534,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.4.8",
+ "h2 0.4.15",
  "http 1.3.1",
  "http-body",
  "http-body-util",
@@ -4026,6 +4047,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "socket2"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4304,41 +4335,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "threadpool"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
-dependencies = [
- "num_cpus",
-]
-
-[[package]]
-name = "thrift"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c6d965454947cc7266d22716ebfd07b18d84ebaf35eec558586bbb2a8cb6b5b"
-dependencies = [
- "byteorder",
- "integer-encoding 1.1.7",
- "log",
- "ordered-float 1.1.1",
- "threadpool",
-]
-
-[[package]]
-name = "thrift"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e54bc85fc7faa8bc175c4bab5b92ba8d9a3ce893d0e9f42cc455c8ab16a9e09"
-dependencies = [
- "byteorder",
- "integer-encoding 3.0.4",
- "log",
- "ordered-float 2.10.1",
- "threadpool",
-]
-
-[[package]]
 name = "time"
 version = "0.3.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4407,7 +4403,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.5.8",
  "tokio-macros",
  "windows-sys 0.52.0",
 ]
@@ -4499,6 +4495,27 @@ dependencies = [
  "serde_spanned",
  "toml_datetime",
  "winnow",
+]
+
+[[package]]
+name = "tonic"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e581ba15a835f4d9ea06c55ab1bd4dce26fc53752c69a04aac00703bfb49ba9"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "bytes",
+ "http 1.3.1",
+ "http-body",
+ "http-body-util",
+ "percent-encoding",
+ "pin-project",
+ "prost",
+ "tokio-stream",
+ "tower-layer",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -4883,6 +4900,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
 
 [[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
 name = "windows-registry"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4899,7 +4922,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c64fd11a4fd95df68efcfee5f44a294fe71b8bc6a91993e2791938abcc712252"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.1",
 ]
 
 [[package]]
@@ -4908,7 +4931,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87fa48cc5d406560701792be122a10132491cff9d0aeb23583cc2dcafc847319"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.1",
 ]
 
 [[package]]
@@ -4927,6 +4950,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link 0.2.1",
 ]
 
 [[package]]

--- a/cincinnati/Cargo.toml
+++ b/cincinnati/Cargo.toml
@@ -34,7 +34,7 @@ tar = "^0.4.40"
 dkregistry = { git = "https://github.com/camallo/dkregistry-rs.git", rev = "89d190c313653afabee66032a4c88efd804f0829" }
 itertools = "^0.13"
 serde_yaml = "^0.9.34"
-opentelemetry = "0.14.0"
+opentelemetry = "0.30"
 strum = "^0.26"
 strum_macros = "^0.25"
 walkdir = "2.5.0"

--- a/cincinnati/src/plugins/internal/cincinnati_graph_fetch.rs
+++ b/cincinnati/src/plugins/internal/cincinnati_graph_fetch.rs
@@ -13,7 +13,7 @@ use commons::prelude_errors::*;
 use commons::tracing::{get_tracer, set_context};
 use opentelemetry::{
     trace::{get_active_span, mark_span_as_active, Tracer},
-    Context as ot_context, Key,
+    Context as ot_context, KeyValue,
 };
 
 use cached::{proc_macro::cached, Return};
@@ -169,7 +169,7 @@ impl CincinnatiGraphFetchPlugin {
                     self.http_upstream_reqs.inc();
                 }
                 get_active_span(|span| {
-                    span.set_attribute(Key::new("cached").bool(call.was_cached));
+                    span.set_attribute(KeyValue::new("cached", call.was_cached));
                 });
                 Ok(InternalIO {
                     graph: call.value,

--- a/commons/Cargo.toml
+++ b/commons/Cargo.toml
@@ -19,10 +19,10 @@ tokio = { version = "1.33", features = [ "rt-multi-thread" ] }
 url = "^2.5"
 futures = "^0.3"
 flate2 = "^1.0.34"
-opentelemetry = "0.14.0"
-opentelemetry-jaeger = "0.13.0"
+opentelemetry = "0.30"
+opentelemetry_sdk = { version = "0.30", features = ["trace"] }
+opentelemetry-otlp = { version = "0.30", features = ["http-proto", "reqwest-client"] }
 reqwest = "^0.12"
-thrift = "0.17"
 tar = "^0.4.40"
 actix-service = "^2.0.2"
 hamcrest2 = "0.3.0"

--- a/commons/src/tracing.rs
+++ b/commons/src/tracing.rs
@@ -3,12 +3,14 @@
 use opentelemetry::{
     global,
     propagation::{Extractor, Injector, TextMapPropagator},
-    sdk::{
-        propagation::TraceContextPropagator,
-        trace::{Config, Sampler, TracerProvider as sdk_tracerprovider},
-    },
-    trace::{Span, TracerProvider},
-    Context, Key,
+    trace::Span,
+    Context, KeyValue,
+};
+use opentelemetry_otlp::WithExportConfig;
+use opentelemetry_sdk::{
+    propagation::TraceContextPropagator,
+    trace::{Sampler, SdkTracerProvider},
+    Resource,
 };
 
 use std::collections::HashMap;
@@ -19,7 +21,7 @@ use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
 
 use crate::prelude_errors::*;
 
-/// init_tracer sets up Jaeger tracer
+/// init_tracer sets up an OTLP tracer (compatible with Jaeger ≥1.35 and any OTLP collector).
 pub fn init_tracer(name: &'static str, maybe_agent_endpoint: Option<String>) -> Fallible<()> {
     // Skip provider config if agent endpoint is not set
     let agent_endpoint = match maybe_agent_endpoint {
@@ -27,18 +29,19 @@ pub fn init_tracer(name: &'static str, maybe_agent_endpoint: Option<String>) -> 
         Some(s) => s,
     };
 
-    let exporter = opentelemetry_jaeger::new_pipeline()
-        .with_agent_endpoint(agent_endpoint)
-        .with_service_name(name.to_string())
-        .with_tags(vec![Key::new("exporter").string("jaeger")])
-        .init_exporter()?;
+    let exporter = opentelemetry_otlp::SpanExporter::builder()
+        .with_http()
+        .with_endpoint(agent_endpoint)
+        .build()?;
 
-    let provider = sdk_tracerprovider::builder()
+    let provider = SdkTracerProvider::builder()
+        .with_sampler(Sampler::AlwaysOn)
+        .with_resource(
+            Resource::builder_empty()
+                .with_attribute(KeyValue::new("service.name", name))
+                .build(),
+        )
         .with_simple_exporter(exporter)
-        .with_config(Config {
-            sampler: Box::new(Sampler::AlwaysOn),
-            ..Default::default()
-        })
         .build();
     global::set_tracer_provider(provider);
 
@@ -47,7 +50,7 @@ pub fn init_tracer(name: &'static str, maybe_agent_endpoint: Option<String>) -> 
 
 /// get_tracer returns an instance of global tracer
 pub fn get_tracer() -> global::BoxedTracer {
-    global::tracer_provider().get_tracer("", None)
+    global::tracer("cincinnati")
 }
 
 struct HttpHeaderMapCarrier<'a>(&'a HttpHeaderMap);
@@ -114,10 +117,10 @@ pub fn set_context(context: Context, headers: &mut HeaderMap) -> crate::errors::
 }
 
 /// Add span attributes from servicerequest
-pub fn set_span_tags(req_path: &str, headers: &HttpHeaderMap, span: &mut dyn Span) {
-    span.set_attribute(Key::new("path").string(req_path.to_string()));
+pub fn set_span_tags<S: Span>(req_path: &str, headers: &HttpHeaderMap, span: &mut S) {
+    span.set_attribute(KeyValue::new("path", req_path.to_string()));
     headers.iter().for_each(|(k, v)| {
         let value = v.to_str().unwrap().to_string();
-        span.set_attribute(Key::new(format!("header.{}", k)).string(value))
+        span.set_attribute(KeyValue::new(format!("header.{}", k), value))
     });
 }

--- a/graph-builder/Cargo.toml
+++ b/graph-builder/Cargo.toml
@@ -37,7 +37,7 @@ parking_lot = "^0.12"
 tempfile = "^3.8.0"
 async-trait = "^0.1"
 custom_debug_derive = "^0.5"
-opentelemetry = "0.14.0"
+opentelemetry = "0.30"
 actix-service = "2.0.2"
 
 [build-dependencies]

--- a/graph-builder/src/config/settings.rs
+++ b/graph-builder/src/config/settings.rs
@@ -81,7 +81,7 @@ pub struct AppSettings {
     /// Plugin configuration.
     pub plugin_settings: Vec<Box<dyn PluginSettings>>,
 
-    /// Jaeger host and port for tracing support
+    /// OTLP HTTP endpoint for tracing support (e.g. http://host:4318)
     pub tracing_endpoint: Option<String>,
 }
 

--- a/graph-builder/src/main.rs
+++ b/graph-builder/src/main.rs
@@ -114,7 +114,7 @@ async fn main() -> Result<(), Error> {
             .wrap(middleware::Compress::default())
             .wrap_fn(|req, srv| {
                 let parent_context = get_context(&req);
-                let mut span = get_tracer().start_with_context("request", parent_context);
+                let mut span = get_tracer().start_with_context("request", &parent_context);
                 set_span_tags(req.path(), req.headers(), &mut span);
                 let _active_span = mark_span_as_active(span);
                 let cx = ot_context::current();
@@ -142,7 +142,7 @@ async fn main() -> Result<(), Error> {
             .wrap(middleware::Compress::default())
             .wrap_fn(|req, srv| {
                 let parent_context = get_context(&req);
-                let mut span = get_tracer().start_with_context("request", parent_context);
+                let mut span = get_tracer().start_with_context("request", &parent_context);
                 set_span_tags(req.path(), req.headers(), &mut span);
                 let _active_span = mark_span_as_active(span);
                 let cx = ot_context::current();

--- a/metadata-helper/Cargo.toml
+++ b/metadata-helper/Cargo.toml
@@ -19,7 +19,7 @@ futures = "^0.3"
 hyper = "^1.1"
 lazy_static = "^1.5.0"
 log = "^0.4.20"
-opentelemetry = "0.14.0"
+opentelemetry = "0.30"
 parking_lot = "^0.12"
 prometheus = "0.13"
 semver = { version = "^1.0.16", features = [ "serde" ] }

--- a/metadata-helper/src/config/settings.rs
+++ b/metadata-helper/src/config/settings.rs
@@ -33,7 +33,7 @@ pub struct AppSettings {
     /// directory to store signatures
     pub signatures_dir: String,
 
-    /// Jaeger host and port for tracing support
+    /// OTLP HTTP endpoint for tracing support (e.g. http://host:4318)
     pub tracing_endpoint: Option<String>,
 
     /// Actix-web maximum number of pending connections, defaults to 2048: https://docs.rs/actix-web/latest/actix_web/struct.HttpServer.html#method.backlog

--- a/policy-engine/Cargo.toml
+++ b/policy-engine/Cargo.toml
@@ -29,7 +29,7 @@ toml = "^0.8.2"
 url = "^2.5"
 tempfile = "^3.8.0"
 custom_debug_derive = "^0.5"
-opentelemetry = "0.14.0"
+opentelemetry = "0.30"
 actix-service = "2.0.2"
 
 [build-dependencies]

--- a/policy-engine/src/config/settings.rs
+++ b/policy-engine/src/config/settings.rs
@@ -50,7 +50,7 @@ pub struct AppSettings {
     /// Required client parameters for the main service.
     pub mandatory_client_parameters: HashSet<String>,
 
-    /// Jaeger host and port for tracing support
+    /// OTLP HTTP endpoint for tracing support (e.g. http://host:4318)
     pub tracing_endpoint: Option<String>,
 
     /// Actix-web maximum number of pending connections, defaults to 2048: https://docs.rs/actix-web/latest/actix_web/struct.HttpServer.html#method.backlog


### PR DESCRIPTION
## Summary

Fixes OCPBUGS-99935 (CVE-2026-55969) and OCPBUGS-100030 (CVE-2026-43871) — both Apache Thrift vulnerabilities fixed in Thrift ≥ 0.24.0.

`commons/Cargo.toml` had two paths pulling in old `thrift` versions:
- **direct**: `thrift = "0.17"`
- **indirect**: `opentelemetry-jaeger = "0.13.0"` → `thrift 0.13.0`

Every released version of `opentelemetry-jaeger` (0.13–0.22) pins `thrift ^0.17.0` (`<0.18.0`), making thrift 0.24.0 unreachable. A simple bump is not sufficient.

**Fix**: replace `opentelemetry-jaeger` with `opentelemetry-otlp`, which has no Thrift dependency. `opentelemetry-jaeger` is officially deprecated upstream; OTLP is the recommended successor. Jaeger natively supports OTLP since v1.35 (2022), so no observability capability is lost.

This requires upgrading `opentelemetry` 0.14 → 0.30 and adopting the `opentelemetry_sdk` crate (split from the main crate in opentelemetry 0.20). `opentelemetry-otlp 0.30` is used rather than the latest 0.32 because 0.31+ pulls in `prost 0.14` (MSRV rustc 1.85) while CI runs rustc 1.84.1; 0.30 uses `prost 0.13` and `reqwest 0.12`, both compatible.

## Changes

- `commons/Cargo.toml`: remove `opentelemetry-jaeger`, `thrift`; add `opentelemetry_sdk 0.30`, `opentelemetry-otlp 0.30`; bump `opentelemetry` to 0.30
- `commons/src/tracing.rs`: replace Jaeger pipeline with OTLP HTTP exporter; fix API changes (`dyn Span` → generic, `Key::new(...).string/bool()` → `KeyValue::new(...)`, `TraceContextPropagator` import moved to `opentelemetry_sdk`)
- `cincinnati/src/plugins/internal/cincinnati_graph_fetch.rs`: `Key::new("cached").bool(...)` → `KeyValue::new("cached", ...)`
- `graph-builder/src/main.rs`: `start_with_context(name, cx)` → `start_with_context(name, &cx)` (`&Context` in 0.30)
- `{graph-builder,metadata-helper,policy-engine}/Cargo.toml`: `opentelemetry` 0.14.0 → 0.30
- `{graph-builder,metadata-helper,policy-engine}/src/config/settings.rs`: update `tracing_endpoint` doc comment to reflect OTLP

## Deployment note

The `--service.tracing_endpoint` flag now expects an OTLP HTTP URL (e.g. `http://jaeger-collector:4318`) instead of a Jaeger UDP agent address (e.g. `jaeger-agent:6831`). Deployments with tracing enabled will need this flag updated. Deployments without tracing (endpoint not set, which is the default) are unaffected. The `cincinnati-operator` does not configure this flag and requires no changes.

## Test plan

- [x] `cargo build` — clean, no errors
- [x] `cargo test` — all pre-existing tests pass; 5 failures in `cincinnati_graph_fetch` are pre-existing on `master` (confirmed by running against unmodified tree)
- [x] `thrift` absent from `Cargo.lock` after change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Updated telemetry support to OpenTelemetry 0.30.
  * Migrated tracing export from Jaeger to OTLP over HTTP.
  * Improved trace context propagation across HTTP requests.
  * Enabled consistent service identification and sampling for exported traces.

* **Documentation**
  * Updated tracing configuration guidance with OTLP HTTP endpoint examples.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->