### PR TITLE
OCPBUGS-81471: lower certificate parse failure log to trace level

### DIFF
--- a/cincinnati/src/plugins/internal/graph_builder/commons.rs
+++ b/cincinnati/src/plugins/internal/graph_builder/commons.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 
 use actix_web::Error;
 use commons::Fallible;
-use log::debug;
+use log::{debug, trace};
 use reqwest::Certificate;
 
 /// Retrives all the .pem and .crt certificate files from the directory.
@@ -33,7 +33,7 @@ pub fn get_certs_from_dir(dir: &Path) -> Fallible<Vec<Certificate>, Error> {
                                         );
                                         certs.push(certificate.unwrap());
                                     } else {
-                                        debug!(
+                                        trace!(
                                             "unable to process certificate {}: {}",
                                             path.file_name().to_str().unwrap_or_default(),
                                             certificate.unwrap_err()


### PR DESCRIPTION
## Summary

Lowers the log level for unparseable certificate files from `debug!` to `trace!` in the graph_builder's `get_certs_from_dir` function.

## Problem

In air-gapped environments, the graph_builder logs a distracting message every time it encounters `ca-bundle.trust.crt`:

```
[DEBUG cincinnati::plugins::internal::graph_builder::commons] unable to process certificate ca-bundle.trust.crt: builder error: error:0909006C:PEM routines:get_name:no start line
```

This file contains `TRUSTED CERTIFICATE` PEM blocks (with extra trust metadata), not standard `CERTIFICATE` blocks, so `reqwest::Certificate::from_pem()` rejects them. The message is harmless but confusing — operators investigating real issues may mistake it for a problem.

## Fix

Change the log macro from `debug!` to `trace!`, so the message only appears at the most verbose logging level. This keeps it available for deep troubleshooting while removing noise from normal debug output.

## Testing

The change is a single log-level adjustment with no behavioral impact on certificate loading.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced the visibility of certificate-processing failure logs to minimize unnecessary debug-level noise.
  * Successful certificate additions continue to be logged at debug level.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->