### PR TITLE
OCPBUGS-114563: Bump actix-files to 0.6.10 for CVE fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -61,9 +61,9 @@ dependencies = [
 
 [[package]]
 name = "actix-files"
-version = "0.6.6"
+version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0773d59061dedb49a8aed04c67291b9d8cf2fe0b60130a381aab53c6dd86e9be"
+checksum = "df8c4f30e3272d7c345f88ae0aac3848507ef5ba871f9cc2a41c8085a0f0523b"
 dependencies = [
  "actix-http",
  "actix-service",
@@ -71,7 +71,7 @@ dependencies = [
  "actix-web",
  "bitflags 2.9.0",
  "bytes",
- "derive_more 0.99.19",
+ "derive_more 2.0.1",
  "futures-core",
  "http-range",
  "log",

--- a/graph-builder/Cargo.toml
+++ b/graph-builder/Cargo.toml
@@ -9,7 +9,7 @@ build = "src/build.rs"
 actix = "0.13.2"
 actix-web = "^4.4.1"
 chrono = "^0.4.38"
-actix-files = "^0.6.5"
+actix-files = "^0.6.10"
 cincinnati = { path = "../cincinnati" }
 commons = { path = "../commons" }
 env_logger = "^0.10"

--- a/metadata-helper/Cargo.toml
+++ b/metadata-helper/Cargo.toml
@@ -8,7 +8,7 @@ build = "src/build.rs"
 [dependencies]
 actix = "0.13.2"
 actix-cors = "^0.6.5"
-actix-files = "^0.6.5"
+actix-files = "^0.6.10"
 actix-service = "2.0.2"
 actix-web = "^4.4.1"
 cincinnati = { path = "../cincinnati" }


### PR DESCRIPTION
Hello. This is a PR to bump actix-files to 0.6.10 to solve [this CVE](https://www.cve.org/CVERecord?id=CVE-2026-72813).
(I have never proposed a CVE fix in Cincinnati before, so please let me know if I've missed something.)
Thanks!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated underlying application components to newer compatible versions.
  * No changes to public features or user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->